### PR TITLE
Adding missing requirement: coloredlogs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(name='iocage',
           'click',
           'texttable',
           'requests',
-          'tqdm'
+          'tqdm',
+          'coloredlogs'
       ],
       setup_requires=['pytest-runner'],
       entry_points={


### PR DESCRIPTION
Following the installation instructions I get the traceback
```
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 6, in <module>
    from iocage.main import main
  File "/usr/local/lib/python3.6/site-packages/iocage-0.9.7-py3.6.egg/iocage/main.py", line 14, in <module>
    from iocage.lib.ioc_check import IOCCheck
  File "/usr/local/lib/python3.6/site-packages/iocage-0.9.7-py3.6.egg/iocage/lib/ioc_check.py", line 7, in <module>
    from iocage.lib.ioc_common import checkoutput
  File "/usr/local/lib/python3.6/site-packages/iocage-0.9.7-py3.6.egg/iocage/lib/ioc_common.py", line 12, in <module>
    from iocage.lib import ioc_logger
  File "/usr/local/lib/python3.6/site-packages/iocage-0.9.7-py3.6.egg/iocage/lib/ioc_logger.py", line 6, in <module>
    import coloredlogs
ModuleNotFoundError: No module named 'coloredlogs'
```

Adding the coloredlogs dependency fixes the problem

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
